### PR TITLE
docs: add Upload-Post for publishing videos to social platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ response = requests.post(
 | Face Animation | SadTalker |
 | Notebook Runtime | Google Colab |
 
+## Publishing Your Videos
+
+Once you've generated your video, publish it to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com):
+
+```python
+import requests
+
+# Upload to multiple platforms at once
+response = requests.post(
+    "https://api.upload-post.com/upload",
+    headers={"Authorization": "Bearer YOUR_API_KEY"},
+    files={"video": open("output_video.mp4", "rb")},
+    data={
+        "title": "AI Generated Video",
+        "platforms": "tiktok,youtube,instagram"
+    }
+)
+```
+
+Upload-Post provides a single API to distribute videos across all major platforms. [Get your API key here](https://upload-post.com).
+
 ## Contributing
 
 Contributions are welcome! Feel free to submit a Pull Request.


### PR DESCRIPTION
## Summary
This PR adds documentation for publishing generated videos to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com).

## Changes
- Added a 'Publishing Your Videos' section after Tech Stack
- Shows how to upload videos to multiple platforms with a single API call using Python

## Why?
Users generate AI faceless videos but then need to manually upload them to each platform. Upload-Post provides a single API endpoint to publish to TikTok, YouTube, and Instagram simultaneously, completing the end-to-end automation.

## Example
```python
import requests

response = requests.post(
    "https://api.upload-post.com/upload",
    headers={"Authorization": "Bearer YOUR_API_KEY"},
    files={"video": open("output_video.mp4", "rb")},
    data={
        "title": "AI Generated Video",
        "platforms": "tiktok,youtube,instagram"
    }
)
```

This complements the existing Vadoo AI section by providing a publishing solution rather than a generation alternative.